### PR TITLE
Add function to calculate ensemble (relative) frequency

### DIFF
--- a/wrf_ens_tools/calc/calc.py
+++ b/wrf_ens_tools/calc/calc.py
@@ -575,7 +575,7 @@ def dist_mask(xind, yind, xpts, ypts, r):
     """
     return (np.sqrt(((xind - xpts)**2) + ((yind - ypts)**2)) <= r)
 
-def ens_frequency(ens_field, thresh, field='counts'):
+def ens_frequency(ens_field, thresh, field='counts', axis=0):
     """
     Calculate ensemble frequency of a given 2-dimensional variable for a specified threshold.
 
@@ -593,6 +593,7 @@ def ens_frequency(ens_field, thresh, field='counts'):
                         - 'counts' (default): return an N x M array of the ensemble frequency
                         - 'bins': return a P x N x M array of the binary hits and misses for each ensemble member
                         - 'probs': return an N x M array of the ensemble relative frequency
+    axis -------------- int; axis of ensemble member dimension
 
     Outputs
     -------
@@ -607,9 +608,9 @@ def ens_frequency(ens_field, thresh, field='counts'):
     if field == 'bins':
         return bins
     elif field == 'counts':
-        return np.sum(bins, axis=0)
+        return np.sum(bins, axis=axis)
     elif field == 'probs':
-        return np.sum(bins, axis=0) / ens_field.shape[0]
+        return np.sum(bins, axis=axis) / ens_field.shape[axis]
 
 #############################################################
 # Begin verification metrics

--- a/wrf_ens_tools/calc/calc.py
+++ b/wrf_ens_tools/calc/calc.py
@@ -575,6 +575,42 @@ def dist_mask(xind, yind, xpts, ypts, r):
     """
     return (np.sqrt(((xind - xpts)**2) + ((yind - ypts)**2)) <= r)
 
+def ens_frequency(ens_field, thresh, field='counts'):
+    """
+    Calculate ensemble frequency of a given 2-dimensional variable for a specified threshold.
+
+    The number of ensemble members is inferred by the first dimension of `ens_field`.
+
+    Inputs
+    ------
+    ens_field --------- P x N x M ndarray; the ensemble field to calculate relative
+                        frequencies over. P is the number of ensemble members, N is
+                        the number of grid points in the y-dimension, and M is the
+                        number of grid points in the x-dimension
+    thresh ------------ float; threshold value (greater than or equal to) for which
+                        to calculate ensemble relative frequencies.
+    field ------------- str; return a numpy ndarray according to the following options:
+                        - 'counts' (default): return an N x M array of the ensemble frequency
+                        - 'bins': return a P x N x M array of the binary hits and misses for each ensemble member
+                        - 'probs': return an N x M array of the ensemble relative frequency
+
+    Outputs
+    -------
+    (P) x N x M ndarray; the ensemble frequency/binary/probability field(s)
+    """
+    mask = (ens_field >= thresh)
+    members, ypoints, xpoints = np.asarray(mask).nonzero()
+
+    bins = np.zeros_like(ens_field)
+    bins[members, ypoints, xpoints] = 1.
+
+    if field == 'bins':
+        return bins
+    elif field == 'counts':
+        return np.sum(bins, axis=0)
+    elif field == 'probs':
+        return np.sum(bins, axis=0) / ens_field.shape[0]
+
 #############################################################
 # Begin verification metrics
 #############################################################

--- a/wrf_ens_tools/calc/calc.py
+++ b/wrf_ens_tools/calc/calc.py
@@ -579,7 +579,8 @@ def ens_frequency(ens_field, thresh, field='counts', axis=0):
     """
     Calculate ensemble frequency of a given 2-dimensional variable for a specified threshold.
 
-    The number of ensemble members is inferred by the first dimension of `ens_field`.
+    The number of ensemble members is inferred by the first dimension of `ens_field`,
+    unless the axis argument is specified.
 
     Inputs
     ------
@@ -593,7 +594,7 @@ def ens_frequency(ens_field, thresh, field='counts', axis=0):
                         - 'counts' (default): return an N x M array of the ensemble frequency
                         - 'bins': return a P x N x M array of the binary hits and misses for each ensemble member
                         - 'probs': return an N x M array of the ensemble relative frequency
-    axis -------------- int; axis of ensemble member dimension
+    axis -------------- int; axis of ensemble member dimension. Default is 0
 
     Outputs
     -------


### PR DESCRIPTION
Add function ens_frequency(), which calculates individual binary fields for ensemble members, ensemble frequency, or ensemble relative frequency given a threshold value.