### PR TITLE
Update Dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,10 @@ name: wrf-devel
 channels:
   - conda-forge/label/testing
   - conda-forge
+  - scitools
 dependencies:
   - python=3
+  - metpy=1
   - siphon
   - numpy
   - scipy
@@ -14,12 +16,13 @@ dependencies:
   - pandas
   - wrf-python
   - jupyter
-  - pytest>=2.4
+  - jupyterlab
+  - pytest
   - pytest-cov
   - pytest-flake8
   - pytest-mpl
   - pytest-runner
-  - flake8-builtins!=1.4.0
+  - flake8-builtins
   - flake8-comprehensions
   - flake8-copyright
   - flake8-docstrings
@@ -29,5 +32,7 @@ dependencies:
   - flake8-print
   - flake8-quotes
   - pep8-naming
-  - pyproj
+  - pyproj<3.0
   - cartopy
+  - dask
+  - cmocean

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools import setup
 setup(
     name='wrf-ens-tools',
     version='0.1',
-    install_requires=['netcdf4', 'numpy', 'scipy', 'xarray', 'pandas', 'pyproj',
+    install_requires=['netcdf4', 'numpy', 'scipy', 'xarray', 'pandas', 'pyproj<3.0',
                       'wrf-python', 'matplotlib', 'siphon', 'cartopy', 'sklearn',
-                      'dask', 'metpy'],
+                      'dask', 'metpy>=1.0', 'cmocean'],
     license='BSD-3',
     author='Austin Coleman, Russel Manser, Tyler Wixtrom',
 )


### PR DESCRIPTION
Closes #20. Now requires MetPy 1.0. I don't think this will break anything but I don't have the reference files to run all of the tests.